### PR TITLE
docs: English Conventional Commits, drop gitmoji

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,18 +15,19 @@ Nommage des branches : `<type>/<sujet-court>`, par exemple
 
 ## Messages de commit
 
-[Gitmoji](https://gitmoji.dev) suivi du format
-[Conventional Commits](https://www.conventionalcommits.org/fr/) :
+Format [Conventional Commits](https://www.conventionalcommits.org/), rédigé en
+anglais, sans emoji :
 
 ```
-✨ feat: ajoute l'export PDF des factures
-🐛 fix: corrige le décalage de fuseau horaire
-♻️ refactor: extrait la validation dans un module dédié
-⬆️ chore: passe Astro en 7.2
-📝 docs: documente la procédure de déploiement
+feat: add PDF export for invoices
+fix: correct the invoice timezone offset
+refactor: extract validation into a dedicated module
+chore: bump Astro to 7.2
+docs: document the deployment procedure
 ```
 
-Le corps du message explique le *pourquoi* — le *quoi* se lit dans le diff.
+Le corps du message explique le *pourquoi* — le *quoi* se lit dans le diff. Les
+titres de pull request suivent la même convention.
 
 ## Labels
 


### PR DESCRIPTION
Aligne le `CONTRIBUTING.md` de l'organisation sur la convention retenue : anglais, Conventional Commits, sans gitmoji.

## Pourquoi ce fichier

Il est **hérité par les 37 repos** de l'org, et il imposait l'inverse :

```
[Gitmoji](https://gitmoji.dev) suivi du format Conventional Commits :

✨ feat: ajoute l'export PDF des factures
```

Or aucun repo actif ne suivait cette règle :

| Repo | Convention réelle observée |
|---|---|
| `techtown-infra` | Anglais, Conventional Commits, sans gitmoji |
| `techtown-marketplace` | Français, Conventional Commits, sans gitmoji |

## Le déclencheur

techtown-marketplace#7 fait absorber `repo-template` par le plugin `project-setup`. Ce plugin génère un `AGENTS.md` dans chaque nouveau repo, avec les conventions de commit dedans.

Sans cette PR, chaque nouveau repo naîtrait avec un `AGENTS.md` qui contredit le `CONTRIBUTING.md` qu'il hérite — et c'est le second que les humains lisent.

## Portée

Seule la section « Messages de commit » change. Le fichier **reste en français** : la décision porte sur la langue des messages de commit, pas sur celle de la documentation destinée aux collaborateurs.

Le lien Conventional Commits pointait vers la traduction française (`/fr/`), il pointe maintenant vers la page canonique puisque la convention est désormais anglophone.

Ajout d'une phrase : les titres de PR suivent la même convention, ce que le fichier ne disait pas.

## Non modifié volontairement

Les emoji dans les **noms** des templates d'issue (`🐛 Rapport de bug`, `✨ Demande d'évolution`) sont conservés : ils étiquettent le sélecteur d'issues, ce n'est pas une convention de commit.

La section « Labels » est déjà cohérente avec le `dependabot.yml` du plugin (`dependencies`, `automated`, `ci/cd`, `terraform`).